### PR TITLE
added error-ex Error wrapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,25 @@
 'use strict';
+var errorEx = require('error-ex');
 var fallback = require('./vendor/parse');
+
+var JSONError = errorEx('JSONError', {
+	fileName: errorEx.append('in %s')
+});
 
 module.exports = function (x, reviver) {
 	try {
-		return JSON.parse(x, reviver);
-	} catch (err) {
-		fallback.parse(x, {
-			mode: 'json',
-			reviver: reviver
-		});
+		try {
+			return JSON.parse(x, reviver);
+		} catch (err) {
+			fallback.parse(x, {
+				mode: 'json',
+				reviver: reviver
+			});
 
+			throw err;
+		}
+	} catch (err) {
+		JSONError.call(err);
 		throw err;
 	}
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "string",
     "str"
   ],
+  "dependencies": {
+    "error-ex": "^1.1.0"
+  },
   "devDependencies": {
     "ava": "0.0.4",
     "xo": "*"

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,20 @@ SyntaxError: Unexpected token }
 
 parseJson(json);
 /*
-SyntaxError: Trailing comma in object at 3:1
+JSONError: Trailing comma in object at 3:1
+}
+^
+*/
+
+try {
+	parseJson(json);
+} catch (err) {
+	err.fileName = 'foo.json';
+	throw err;
+}
+
+/*
+JSONError: Trailing comma in object at 3:1 in foo.json
 }
 ^
 */

--- a/test.js
+++ b/test.js
@@ -8,7 +8,16 @@ test(function (t) {
 
 	assert.throws(function () {
 		fn('{\n\t"foo": true,\n}');
-	}, /SyntaxError: Trailing/);
+	}, /JSONError: Trailing/);
+
+	assert.throws(function () {
+		try {
+			fn('{\n\t"foo": true,\n}');
+		} catch (err) {
+			err.fileName = 'foo.json';
+			throw err;
+		}
+	}, /JSONError: Trailing.*in foo\.json/);
 
 	t.end();
 });


### PR DESCRIPTION
Added ability to tack on the filename to the exception using [`error-ex`](/Qix-/node-error-ex), as requested.

Went ahead and changed the name of the Error; let me know if you want it changed back to `SyntaxError`.