### PR TITLE
Append position in file to end of error message to the end

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,19 @@
 const errorEx = require('error-ex');
 const fallback = require('./vendor/parse');
 
+function appendPosition(message) {
+	const numbers = message.match(/ at (\d+:\d+) in/);
+	return message + ':' + numbers[1];
+}
+
 const JSONError = errorEx('JSONError', {
-	fileName: errorEx.append('in %s')
+	fileName: errorEx.append('in %s'),
+	appendPosition: {
+		message: (shouldAppend, original) => {
+			const originalMessage = original[0];
+			return shouldAppend ? appendPosition(originalMessage) : originalMessage;
+		}
+	}
 });
 
 module.exports = (input, reviver, filename) => {
@@ -28,6 +39,7 @@ module.exports = (input, reviver, filename) => {
 
 		if (filename) {
 			jsonErr.fileName = filename;
+			jsonErr.appendPosition = true;
 		}
 
 		throw jsonErr;

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import m from '.';
 
-const reJsonErr = /JSONError: Trailing.*in foo\.json/;
+const reJsonErr = /JSONError: Trailing.* at 3:1 in foo\.json:3:1/;
 
 test(t => {
 	t.truthy(m('{"foo": true}'));
@@ -15,6 +15,7 @@ test(t => {
 			m('{\n\t"foo": true,\n}');
 		} catch (err) {
 			err.fileName = 'foo.json';
+			err.appendPosition = true;
 			throw err;
 		}
 	}, reJsonErr);


### PR DESCRIPTION
This enables users to open the editor directly from the terminal, as suggested in #9.

The position in the file will be appended to the error message in case there is a `fileName` set on the error.

Example output:
`Trailing comma in object at 3:1 in foo.json:3:1`