### PR TITLE
Add code frame

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 'use strict';
 const errorEx = require('error-ex');
 const fallback = require('json-parse-better-errors');
+const {default: LinesAndColumns} = require('lines-and-columns');
+const {codeFrameColumns} = require('@babel/code-frame');
 
 const JSONError = errorEx('JSONError', {
-	fileName: errorEx.append('in %s')
+	fileName: errorEx.append('in %s'),
+	codeFrame: errorEx.append('\n\n%s\n')
 });
 
 module.exports = (string, reviver, filename) => {
@@ -21,10 +24,25 @@ module.exports = (string, reviver, filename) => {
 		}
 	} catch (error) {
 		error.message = error.message.replace(/\n/g, '');
+		const indexMatch = error.message.match(/in JSON at position (\d+) while parsing near/);
 
 		const jsonError = new JSONError(error);
 		if (filename) {
 			jsonError.fileName = filename;
+		}
+
+		if (indexMatch && indexMatch.length > 0) {
+			const lines = new LinesAndColumns(string);
+			const index = Number(indexMatch[1]);
+			const location = lines.locationForIndex(index);
+
+			const codeFrame = codeFrameColumns(
+				string,
+				{start: {line: location.line + 1, column: location.column + 1}},
+				{highlightCode: true}
+			);
+
+			jsonError.codeFrame = codeFrame;
 		}
 
 		throw jsonError;

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
 		"string"
 	],
 	"dependencies": {
+		"@babel/code-frame": "^7.0.0",
 		"error-ex": "^1.3.1",
-		"json-parse-better-errors": "^1.0.1"
+		"json-parse-better-errors": "^1.0.1",
+		"lines-and-columns": "^1.1.6"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/readme.md
+++ b/readme.md
@@ -30,12 +30,22 @@ SyntaxError: Unexpected token }
 parseJson(json);
 /*
 JSONError: Unexpected token } in JSON at position 16 while parsing near '{      "foo": true,}'
+
+  1 | {
+  2 |   "foo": true,
+> 3 | }
+    | ^
 */
 
 
 parseJson(json, 'foo.json');
 /*
 JSONError: Unexpected token } in JSON at position 16 while parsing near '{      "foo": true,}' in foo.json
+
+  1 | {
+  2 |   "foo": true,
+> 3 | }
+    | ^
 */
 
 
@@ -48,6 +58,11 @@ try {
 }
 /*
 JSONError: Unexpected token } in JSON at position 16 while parsing near '{      "foo": true,}' in foo.json
+
+  1 | {
+  2 |   "foo": true,
+> 3 | }
+    | ^
 */
 ```
 


### PR DESCRIPTION
I find it easier to locate the error with a than just the index of the error. E.g. trailing comma in an object:

![image](https://user-images.githubusercontent.com/1404810/47267238-8540b100-d541-11e8-902d-4c85cd95bb9c.png)

Note: This drops support for node 4

I left out tests in case you don't want this