### PR TITLE
Replace dependency `json-parse-better-errors` with fork `json-parse-even-better-errors`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const errorEx = require('error-ex');
-const fallback = require('json-parse-better-errors');
+const fallback = require('json-parse-even-better-errors');
 const {default: LinesAndColumns} = require('lines-and-columns');
 const {codeFrameColumns} = require('@babel/code-frame');
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"@babel/code-frame": "^7.0.0",
 		"error-ex": "^1.3.1",
-		"json-parse-better-errors": "^1.0.1",
+		"json-parse-even-better-errors": "^2.3.0",
 		"lines-and-columns": "^1.1.6"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import parseJson from '.';
 
-const jsonErrorRegex = /Unexpected token }.*in foo\.json?/;
+const jsonErrorRegex = /Unexpected token "}".*in foo\.json/;
 
 test('main', t => {
 	t.truthy(parseJson('{"foo": true}'));
@@ -10,7 +10,7 @@ test('main', t => {
 		parseJson('{\n\t"foo": true,\n}');
 	}, {
 		name: 'JSONError',
-		message: /Unexpected token }/
+		message: /Unexpected token "}"/
 	});
 
 	t.throws(() => {


### PR DESCRIPTION
NPM has created a fork of [zkat/json-parse-better-errors](https://github.com/zkat/json-parse-better-errors) called [zkat/json-parse-even-better-errors](https://github.com/npm/json-parse-even-better-errors) (which I noticed at the [release of npm v7.0.0-beta.6](https://github.com/npm/cli/releases/tag/v7.0.0-beta.6)).

Example of improvement:

```diff
- Unexpected token } in JSON at position 16 while parsing near '{    "foo": true,}'
+ Unexpected token "}" (0x7D) in JSON at position 16 while parsing "{\n\t\"foo\": true,\n}" 
```

There has been a few other minor improvements.