### PR TITLE
Export `JSONError`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const JSONError = errorEx('JSONError', {
 	codeFrame: errorEx.append('\n\n%s\n')
 });
 
-module.exports = (string, reviver, filename) => {
+const parseJson = (string, reviver, filename) => {
 	if (typeof reviver === 'string') {
 		filename = reviver;
 		reviver = null;
@@ -48,3 +48,6 @@ module.exports = (string, reviver, filename) => {
 		throw jsonError;
 	}
 };
+
+parseJson.JSONError = JSONError;
+module.exports = parseJson;

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,9 @@ JSONError: Unexpected token } in JSON at position 16 while parsing near '{      
 try {
 	parseJson(json);
 } catch (error) {
-	error.fileName = 'foo.json';
+	if(error instanceof parseJson.JSONError) {
+		error.fileName = 'foo.json';
+	}
 	throw error;
 }
 /*
@@ -84,6 +86,35 @@ Prescribes how the value originally produced by parsing is transformed, before b
 Type: `string`
 
 Filename displayed in the error message.
+
+#### throws
+
+Type: `JSONError`
+
+Thrown when there is a parsing error and contains displayable information like the codeFrame, and fileName
+
+
+### class JSONError(error: unknown)
+
+#### error (argument)
+
+Type: `unknown`
+
+This is any raised error that the `JSONError` has wrapped
+
+#### Fields
+#### codeFrame
+
+Type: `string`
+
+The printable section of the JSON which produces the error.
+
+#### fileName
+
+Type: `string`
+
+Filename displayed in the error message.
+
 
 ---
 

--- a/test.js
+++ b/test.js
@@ -35,3 +35,8 @@ test('main', t => {
 		}
 	}, jsonErrorRegex);
 });
+
+test('throws exported error error', t => {
+	const error = t.throws(() => parseJson('asdf'));
+	t.truthy(error instanceof parseJson.JSONError);
+});


### PR DESCRIPTION
The error type created was not exported. The alternative is to build your own typeguards by checking for properties you expect on it to see if it's an actual JSONError instead of just using instanceof. We should respect the type system javascript has and let developers use it properly instead of make them guess at what the type of a thing is.