### PR TITLE
Fix Webpack compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,7 @@
-import {createRequire} from 'node:module';
 import errorEx from 'error-ex';
 import fallback from 'json-parse-even-better-errors';
 import {codeFrameColumns} from '@babel/code-frame';
-
-const require = createRequire(import.meta.url);
-const {default: LinesAndColumns} = require('lines-and-columns');
+import LinesAndColumns from 'lines-and-columns';
 
 export const JSONError = errorEx('JSONError', {
 	fileName: errorEx.append('in %s'),
@@ -34,7 +31,8 @@ export default function parseJson(string, reviver, filename) {
 		}
 
 		if (indexMatch && indexMatch.length > 0) {
-			const lines = new LinesAndColumns(string);
+			// eslint-disable-next-line new-cap
+			const lines = new LinesAndColumns.default(string);
 			const index = Number(indexMatch[1]);
 			const location = lines.locationForIndex(index);
 


### PR DESCRIPTION
Hey!

I use this library in my browser App. The webpack can't build the browser app with import (or I don't found how):

```js
import {createRequire} from 'node:module';

const require = createRequire(import.meta.url);
```

May you change the way of import without `createRequire` ?