### PR TITLE
Fix dependency on `lines-and-columns`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import errorEx from 'error-ex';
 import fallback from 'json-parse-even-better-errors';
 import {codeFrameColumns} from '@babel/code-frame';
-import LinesAndColumns from 'lines-and-columns';
+import {LinesAndColumns} from 'lines-and-columns';
 
 export const JSONError = errorEx('JSONError', {
 	fileName: errorEx.append('in %s'),
@@ -31,8 +31,7 @@ export default function parseJson(string, reviver, filename) {
 		}
 
 		if (indexMatch && indexMatch.length > 0) {
-			// eslint-disable-next-line new-cap
-			const lines = new LinesAndColumns.default(string);
+			const lines = new LinesAndColumns(string);
 			const index = Number(indexMatch[1]);
 			const location = lines.locationForIndex(index);
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@babel/code-frame": "^7.16.0",
 		"error-ex": "^1.3.2",
 		"json-parse-even-better-errors": "^2.3.1",
-		"lines-and-columns": "^1.1.6"
+		"lines-and-columns": "^2.0.2"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",


### PR DESCRIPTION
I messed up the minor updates I was making to `lines-and-columns` to use ES modules only, and published a patch update (v1.1.7) instead of a major one (v2.0.0). This had way more downstream effects than I intended. As I couldn't unpublish, I ended up publishing v1.1.9 to fix the issue, but that also included ESM support, but I realize now that was probably a mistake too since it represents a breaking change for anything using ESM itself.

This fixes it for `parse-json` by updating to the v2.0.2 ESM version. Alternatively, you could pin v1.1.6.