### PR TITLE
Add raw codeFrame and fix JSONError type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import type {JsonObject} from 'type-fest';
 /**
 Exposed for `instanceof` checking.
 */
-export type JSONError = Error & { // eslint-disable-line @typescript-eslint/naming-convention
+export class JSONError extends Error { // eslint-disable-line @typescript-eslint/naming-convention
 	/**
 	The filename displayed in the error message, if any.
 	*/
@@ -13,7 +13,7 @@ export type JSONError = Error & { // eslint-disable-line @typescript-eslint/nami
 	The printable section of the JSON which produces the error.
 	*/
 	readonly codeFrame: string;
-};
+}
 
 // Get 'reviver' parameter from JSON.parse()
 type ReviverFn = Parameters<typeof JSON['parse']>['1'];

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,10 @@ export class JSONError extends Error { // eslint-disable-line @typescript-eslint
 	The printable section of the JSON which produces the error.
 	*/
 	readonly codeFrame: string;
+	/**
+	The raw version of codeFrame, without terminal highlight.
+	*/
+	readonly rawCodeFrame: string;
 }
 
 // Get 'reviver' parameter from JSON.parse()

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,8 +13,9 @@ export class JSONError extends Error { // eslint-disable-line @typescript-eslint
 	The printable section of the JSON which produces the error.
 	*/
 	readonly codeFrame: string;
+
 	/**
-	The raw version of codeFrame, without terminal highlight.
+	The raw version of `codeFrame` without colors.
 	*/
 	readonly rawCodeFrame: string;
 }

--- a/index.js
+++ b/index.js
@@ -35,13 +35,11 @@ export default function parseJson(string, reviver, filename) {
 			const index = Number(indexMatch[1]);
 			const location = lines.locationForIndex(index);
 
-			const generateCodeFrame = ({highlightCode}) => {
-				return codeFrameColumns(
-					string,
-					{start: {line: location.line + 1, column: location.column + 1}},
-					{highlightCode},
-				);
-			}
+			const generateCodeFrame = ({highlightCode}) => codeFrameColumns(
+				string,
+				{start: {line: location.line + 1, column: location.column + 1}},
+				{highlightCode},
+			);
 
 			jsonError.codeFrame = generateCodeFrame({highlightCode: true});
 			jsonError.rawCodeFrame = generateCodeFrame({highlightCode: false});

--- a/index.js
+++ b/index.js
@@ -35,13 +35,16 @@ export default function parseJson(string, reviver, filename) {
 			const index = Number(indexMatch[1]);
 			const location = lines.locationForIndex(index);
 
-			const codeFrame = codeFrameColumns(
-				string,
-				{start: {line: location.line + 1, column: location.column + 1}},
-				{highlightCode: true},
-			);
+			const generateCodeFrame = ({highlightCode}) => {
+				return codeFrameColumns(
+					string,
+					{start: {line: location.line + 1, column: location.column + 1}},
+					{highlightCode},
+				);
+			}
 
-			jsonError.codeFrame = codeFrame;
+			jsonError.codeFrame = generateCodeFrame({highlightCode: true});
+			jsonError.rawCodeFrame = generateCodeFrame({highlightCode: false});
 		}
 
 		throw jsonError;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -33,6 +33,12 @@ const jsonError: JSONError = {
 		> 3 | }
 			| ^
 	`,
+	rawCodeFrame: `
+		  1 | {
+		  2 |   "foo": true,
+		> 3 | }
+			| ^
+	`,
 };
 
 expectError(jsonError.codeFrame = '');

--- a/readme.md
+++ b/readme.md
@@ -105,3 +105,9 @@ The filename displayed in the error message.
 Type: `string`
 
 The printable section of the JSON which produces the error.
+
+#### rawCodeFrame
+
+Type: `string`
+
+The raw version of codeFrame, without terminal highlight.

--- a/readme.md
+++ b/readme.md
@@ -110,4 +110,4 @@ The printable section of the JSON which produces the error.
 
 Type: `string`
 
-The raw version of codeFrame, without terminal highlight.
+The raw version of `codeFrame` without colors.

--- a/test.js
+++ b/test.js
@@ -49,3 +49,12 @@ test('throws exported error error', t => {
 		instanceOf: JSONError,
 	});
 });
+
+test('has error frame properties', t => {
+	try {
+		parseJson('{\n\t"foo": true,\n}', 'foo.json');
+	} catch(e) {
+		t.assert(e.codeFrame);
+		t.deepEqual(e.rawCodeFrame, '  1 | {\n  2 | \t\"foo\": true,\n> 3 | }\n    | ^');
+	}
+});

--- a/test.js
+++ b/test.js
@@ -55,6 +55,6 @@ test('has error frame properties', t => {
 		parseJson('{\n\t"foo": true,\n}', 'foo.json');
 	} catch (error) {
 		t.assert(error.codeFrame);
-		t.true(error.rawCodeFrame === '  1 | {\n  2 | \t"foo": true,\n> 3 | }\n    | ^');
+		t.is(error.rawCodeFrame, '  1 | {\n  2 | \t"foo": true,\n> 3 | }\n    | ^');
 	}
 });

--- a/test.js
+++ b/test.js
@@ -53,8 +53,8 @@ test('throws exported error error', t => {
 test('has error frame properties', t => {
 	try {
 		parseJson('{\n\t"foo": true,\n}', 'foo.json');
-	} catch(e) {
-		t.assert(e.codeFrame);
-		t.deepEqual(e.rawCodeFrame, '  1 | {\n  2 | \t\"foo\": true,\n> 3 | }\n    | ^');
+	} catch (error) {
+		t.assert(error.codeFrame);
+		t.true(error.rawCodeFrame === '  1 | {\n  2 | \t"foo": true,\n> 3 | }\n    | ^');
 	}
 });


### PR DESCRIPTION
### Description

Needed to get the code lines without the highlighting, so I have introduced a new property for it. 

Also fixes JSONError to be a class so that the `instanceof` comparison can be used in a Typescript codebase.