### PR TITLE
feat: removed error-ex as dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ import {codeFrameColumns} from '@babel/code-frame';
 import {LinesAndColumns} from 'lines-and-columns';
 
 export class JSONError extends Error {
-	fileName = undefined;
-	codeFrame = undefined;
-	rawCodeFrame = undefined;
+	fileName;
+	codeFrame;
+	rawCodeFrame;
 
 	constructor(message) {
 		super(message);

--- a/index.js
+++ b/index.js
@@ -3,30 +3,33 @@ import {codeFrameColumns} from '@babel/code-frame';
 import {LinesAndColumns} from 'lines-and-columns';
 
 export class JSONError extends Error {
+	fileName = undefined;
+	codeFrame = undefined;
+	rawCodeFrame = undefined;
+
 	constructor(message) {
 		super(message);
 
-		let _messages = message instanceof Error
+		let _message = message instanceof Error
 			? message.message
 			: message;
-
-		delete this.message;
 
 		Object.defineProperty(this, 'message', {
 			configurable: true,
 			enumerable: false,
 			get() {
-				return `${_messages}${this.fileName ? ` in ${this.fileName}` : ''}${this.codeFrame ? `\n\n${this.codeFrame}\n` : ''}`;
+				return `${_message}${this.fileName ? ` in ${this.fileName}` : ''}${this.codeFrame ? `\n\n${this.codeFrame}\n` : ''}`;
 			},
 			set(value) {
-				_messages = value;
+				_message = value;
 			},
 		});
 
 		this.name = 'JSONError';
-		this.fileName = undefined;
-		this.codeFrame = undefined;
-		this.rawCodeFrame = undefined;
+
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, JSONError);
+		}
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,34 @@
-import errorEx from 'error-ex';
 import fallback from 'json-parse-even-better-errors';
 import {codeFrameColumns} from '@babel/code-frame';
 import {LinesAndColumns} from 'lines-and-columns';
 
-export const JSONError = errorEx('JSONError', {
-	fileName: errorEx.append('in %s'),
-	codeFrame: errorEx.append('\n\n%s\n'),
-});
+export class JSONError extends Error {
+	constructor(message) {
+		super(message);
+
+		let _messages = message instanceof Error
+			? message.message
+			: message;
+
+		delete this.message;
+
+		Object.defineProperty(this, 'message', {
+			configurable: true,
+			enumerable: false,
+			get() {
+				return `${_messages}${this.fileName ? ` in ${this.fileName}` : ''}${this.codeFrame ? `\n\n${this.codeFrame}\n` : ''}`;
+			},
+			set(value) {
+				_messages = value;
+			},
+		});
+
+		this.name = 'JSONError';
+		this.fileName = undefined;
+		this.codeFrame = undefined;
+		this.rawCodeFrame = undefined;
+	}
+}
 
 const generateCodeFrame = (string, location, highlightCode = true) =>
 	codeFrameColumns(string, {start: location}, {highlightCode});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 	],
 	"dependencies": {
 		"@babel/code-frame": "^7.21.4",
-		"error-ex": "^1.3.2",
 		"json-parse-even-better-errors": "^3.0.0",
 		"lines-and-columns": "^2.0.3",
 		"type-fest": "^3.8.0"


### PR DESCRIPTION
This will close #38 

Old error object
```
ErrorEXError [JSONError]: Unexpected token "}" (0x7D) in JSON at position 16 while parsing "{\n\t\"foo\": true,\n}" in foo.json 

  1 | {
  2 |   "foo": true,
> 3 | }
    | ^

    at parseJson (file:///parse-json/index.js:52:20)
    at t.throws.message (file:///parse-json/test.js:56:4)
    at ExecutionContext.throws (file:///parse-json/node_modules/ava/lib/assert.js:487:14)
    at file:///parse-json/test.js:54:4
    at Test.callFn (file:///parse-json/node_modules/ava/lib/test.js:523:21)
    at Test.run (file:///parse-json/node_modules/ava/lib/test.js:536:23)
    at Runner.runSingle (file:///parse-json/node_modules/ava/lib/runner.js:285:33)
    at Runner.runTest (file:///parse-json/node_modules/ava/lib/runner.js:367:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0) {
  fileName: 'foo.json',
  codeFrame: '  1 | {\n  2 | \t"foo": true,\n> 3 | }\n    | ^',
  rawCodeFrame: '  1 | {\n  2 | \t"foo": true,\n> 3 | }\n    | ^'
}

```

New error object
```
JSONError: Unexpected token "}" (0x7D) in JSON at position 16 while parsing "{\n\t\"foo\": true,\n}" in foo.json

  1 | {
  2 |   "foo": true,
> 3 | }
    | ^

    at parseJson (file:///parse-json/index.js:74:20)
    at t.throws.message (file:///parse-json/test.js:56:4)
    at ExecutionContext.throws (file:///parse-json/node_modules/ava/lib/assert.js:487:14)
    at file:///parse-json/test.js:54:4
    at Test.callFn (file:///parse-json/node_modules/ava/lib/test.js:523:21)
    at Test.run (file:///parse-json/node_modules/ava/lib/test.js:536:23)
    at Runner.runSingle (file:///parse-json/node_modules/ava/lib/runner.js:285:33)
    at Runner.runTest (file:///parse-json/node_modules/ava/lib/runner.js:367:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0) {
  fileName: 'foo.json',
  codeFrame: '  1 | {\n  2 | \t"foo": true,\n> 3 | }\n    | ^',
  rawCodeFrame: '  1 | {\n  2 | \t"foo": true,\n> 3 | }\n    | ^'
}

```