### PR TITLE
Set return type to `JsonValue`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type {JsonObject} from 'type-fest';
+import type {JsonValue} from 'type-fest';
 
 /**
 Exposed for `instanceof` checking.
@@ -73,7 +73,7 @@ try {
 //     | ^
 ```
 */
-export default function parseJson(string: string, reviver?: Reviver, filename?: string): JsonObject;
+export default function parseJson(string: string, reviver?: Reviver, filename?: string): JsonValue;
 
 /**
 Parse JSON with more helpful errors.
@@ -123,4 +123,4 @@ try {
 //     | ^
 ```
 */
-export default function parseJson(string: string, filename?: string): JsonObject;
+export default function parseJson(string: string, filename?: string): JsonValue;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,13 +1,14 @@
 import {expectType, expectError} from 'tsd';
-import type {JsonObject} from 'type-fest';
+import type {JsonValue} from 'type-fest';
 import parseJson, {type JSONError} from './index.js';
 
 expectError(parseJson());
 expectError(parseJson({foo: true}));
-expectType<JsonObject>(parseJson('{"foo": true}'));
-expectType<JsonObject>(parseJson('{"foo": true}', 'foo.json'));
-expectType<JsonObject>(parseJson('{"foo": true}', (key, value) => String(value)));
-expectType<JsonObject>(parseJson('{"foo": true}', (key, value) => String(value), 'foo.json'));
+expectType<JsonValue>(parseJson('{"foo": true}'));
+expectType<JsonValue>(parseJson('{"foo": true}', 'foo.json'));
+expectType<JsonValue>(parseJson('{"foo": true}', (key, value) => String(value)));
+expectType<JsonValue>(parseJson('{"foo": true}', (key, value) => String(value), 'foo.json'));
+expectType<JsonValue>(parseJson('"foo"'));
 
 expectType<string>((() => {
 	let x: string;

--- a/test.js
+++ b/test.js
@@ -32,6 +32,12 @@ const EXPECTED_CODE_FRAME = `
 
 test('main', t => {
 	t.deepEqual(parseJson('{"foo": true}'), {foo: true});
+	t.deepEqual(parseJson('[{"foo": true}]'), [{foo: true}]);
+
+	t.assert(parseJson('"foo"') === 'foo');
+	t.assert(parseJson('123') === 123);
+	t.assert(parseJson('true') === true);
+	t.assert(parseJson('null') === null);
 
 	t.throws(() => {
 		parseJson(INVALID_JSON_STRING);


### PR DESCRIPTION
As there is nothing that ensures that the JSON is a JSON object and (sadly) JSON allows any of its data types to be used at the top level, even `null`